### PR TITLE
custom hostname and displayname for zabbix

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,7 +78,9 @@ The plugin is configuration to do exactly what you want, by means of the plugin 
     'no_alerting_tag_value': '1',
     'attach_objtag': True,
     'objtag_type': 'nb_type',
-    'objtag_id': 'nb_id'
+    'objtag_id': 'nb_id',
+    'custom_field_hostname':'',
+    'custom_field_display_name':''
 }
 ```
 
@@ -207,6 +209,9 @@ These tags allow you to navigate from a Zabbix host back to the corresponding  N
 | `attach_objtag` | `True`    | Enable or disable auto-tagging      |
 | `objtag_type`   | `nb_type` | Tag name for the NetBox object type |
 | `objtag_id`     | `nb_id`   | Tag name for the NetBox object ID   |
+
+### custom_field_hostname and custom_field_display_name
+You can use these fields to map the connection between NetBox and the Zabbix hostname and display name. The device name is used as the default.
 
 ## Enabling and Disabling Synchronization
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -110,6 +110,8 @@ PLUGINS_CONFIG = {
         'attach_objtag': True,
         'objtag_type': 'nb_type',
         'objtag_id': 'nb_id',
+        'custom_field_hostname':'',
+        'custom_field_display_name':'',
     }
 }
 ```

--- a/nbxsync/__init__.py
+++ b/nbxsync/__init__.py
@@ -117,6 +117,8 @@ class nbxSync(PluginConfig):
         'attach_objtag': False,
         'objtag_type': 'nb_type',
         'objtag_id': 'nb_id',
+        'custom_field_hostname': '',
+        'custom_field_display_name': '',
     }
     queues = []
     validated_config = None

--- a/nbxsync/settings.py
+++ b/nbxsync/settings.py
@@ -112,6 +112,10 @@ class PluginSettingsModel(BaseModel):
     objtag_id: str = Field(default='nb_id')
 
 
+    custom_field_hostname: str = Field(default='')
+    custom_field_display_name: str = Field(default='')
+
+
 # Helper function
 def get_plugin_settings() -> PluginSettingsModel:
     plugin_config = apps.get_app_config('nbxsync')

--- a/nbxsync/utils/sync/hostsync.py
+++ b/nbxsync/utils/sync/hostsync.py
@@ -20,12 +20,33 @@ class HostSync(ZabbixSyncBase):
     def api_object(self):
         return self.api.host
 
-    def get_name_value(self):
+    def get_base_name(self):
         # If the object has the "name" attribute, only return that (Device). If not (cornercase?), return the display string
         if hasattr(self.obj.assigned_object, 'name'):
             return self.obj.assigned_object.name
 
         return str(self.obj.assigned_object)
+
+    def get_name_value(self):
+        base_name = self.get_base_name()
+        cf_name = getattr(self.pluginsettings, 'custom_field_hostname', '')
+        if cf_name and hasattr(self.obj.assigned_object, 'custom_field_data'):
+            cf_value = self.obj.assigned_object.custom_field_data.get(cf_name)
+            if cf_value:
+                return str(cf_value)
+        return base_name
+
+    def get_display_name(self):
+        base_name = self.get_base_name()
+        cf_name = getattr(self.pluginsettings, 'custom_field_display_name', '')
+        if cf_name and hasattr(self.obj.assigned_object, 'custom_field_data'):
+            cf_value = self.obj.assigned_object.custom_field_data.get(cf_name)
+            if cf_value:
+                return str(cf_value)
+        return base_name
+
+    def find_by_name(self):
+        return self.api_object().get(filter={'host': self.sanitize_string(input_str=str(self.get_name_value()))})
 
     def get_create_params(self):
         status = self.obj.assigned_object.status
@@ -41,7 +62,7 @@ class HostSync(ZabbixSyncBase):
 
         return {
             'host': self.sanitize_string(input_str=str(self.get_name_value())),
-            'name': self.get_name_value(),
+            'name': self.get_display_name(),
             'groups': self.get_groups(),
             'status': host_status,
             'description': self.obj.assigned_object.description or '',


### PR DESCRIPTION
Summary:
Introduces configurable fields to link NetBox attributes to Zabbix hostnames and display names.

Changes:

Added new mapping options to the settings.

Fallback: Defaults to device-name if no custom fields are specified.

Provides flexibility for non-standard naming conventions.

Impact:
No breaking changes; maintains backward compatibility with existing setups.