### PR TITLE
Add related object context to Zabbix tag and hostgroup templates

### DIFF
--- a/nbxsync/models/zabbixhostgroupassignment.py
+++ b/nbxsync/models/zabbixhostgroupassignment.py
@@ -51,9 +51,20 @@ class ZabbixHostgroupAssignment(SyncInfoModel, NetBoxModel):
     def get_context(self, **extra_context):
         context = {
             'object': self.assigned_object,
+            'device': self.assigned_object,
             'value': self.zabbixhostgroup.value,
             'name': self.zabbixhostgroup.name,
         }
+        if hasattr(self.assigned_object, 'site'):
+            context['site'] = self.assigned_object.site
+        if hasattr(self.assigned_object, 'tenant'):
+            context['tenant'] = self.assigned_object.tenant
+        if hasattr(self.assigned_object, 'role'):
+            context['role'] = self.assigned_object.role
+        if hasattr(self.assigned_object, 'device_type'):
+            context['device_type'] = self.assigned_object.device_type
+            if hasattr(self.assigned_object.device_type, 'manufacturer'):
+                context['manufacturer'] = self.assigned_object.device_type.manufacturer
         context.update(extra_context)
         return context
 

--- a/nbxsync/models/zabbixtagassignment.py
+++ b/nbxsync/models/zabbixtagassignment.py
@@ -80,11 +80,22 @@ class ZabbixTagAssignment(NetBoxModel):
     def get_context(self, **extra_context):
         context = {
             'object': self.assigned_object,
+            'device': self.assigned_object,
             'tag': self.zabbixtag.tag,
             'value': self.zabbixtag.value,
             'name': self.zabbixtag.name,
             'description': self.zabbixtag.description,
         }
+        if hasattr(self.assigned_object, 'site'):
+            context['site'] = self.assigned_object.site
+        if hasattr(self.assigned_object, 'tenant'):
+            context['tenant'] = self.assigned_object.tenant
+        if hasattr(self.assigned_object, 'role'):
+            context['role'] = self.assigned_object.role
+        if hasattr(self.assigned_object, 'device_type'):
+            context['device_type'] = self.assigned_object.device_type
+            if hasattr(self.assigned_object.device_type, 'manufacturer'):
+                context['manufacturer'] = self.assigned_object.device_type.manufacturer
         context.update(extra_context)
         return context
 

--- a/nbxsync/tests/models/test_zabbixhostgroupassignment.py
+++ b/nbxsync/tests/models/test_zabbixhostgroupassignment.py
@@ -88,8 +88,20 @@ class ZabbixHostgroupAssignmentTestCase(TestCase):
         assignment = ZabbixHostgroupAssignment.objects.create(zabbixhostgroup=self.group, assigned_object_type=self.device_ct, assigned_object_id=self.device.id)
         context = assignment.get_context()
         self.assertIn('object', context)
+        self.assertIn('device', context)
         self.assertIn('value', context)
         self.assertIn('name', context)
+        self.assertEqual(context['device'], self.device)
+
+    def test_render_can_use_related_device_context(self):
+        self.group.value = '{{ site.name }}/{{ device.name }}'
+        self.group.save()
+
+        assignment = ZabbixHostgroupAssignment.objects.create(zabbixhostgroup=self.group, assigned_object_type=self.device_ct, assigned_object_id=self.device.id)
+        rendered, success = assignment.render()
+
+        self.assertTrue(success)
+        self.assertEqual(rendered, f'{self.device.site.name}/{self.device.name}')
 
     def test_render_unexpected_exception(self):
         self.group.value = '{{ object.name }}'

--- a/nbxsync/tests/models/test_zabbixtagassignment.py
+++ b/nbxsync/tests/models/test_zabbixtagassignment.py
@@ -83,11 +83,35 @@ class ZabbixTagAssignmentTestCase(TestCase):
         assignment = ZabbixTagAssignment.objects.create(zabbixtag=self.tag, assigned_object_type=self.device_ct, assigned_object_id=self.device.id)
         context = assignment.get_context(extra='extra_val')
         self.assertEqual(context['object'], self.device)
+        self.assertEqual(context['device'], self.device)
         self.assertEqual(context['tag'], self.tag.tag)
         self.assertEqual(context['value'], self.tag.value)
         self.assertEqual(context['name'], self.tag.name)
         self.assertEqual(context['description'], self.tag.description)
         self.assertEqual(context['extra'], 'extra_val')
+
+    def test_get_context_includes_related_device_objects(self):
+        self.device.device_type = self.device_type
+        self.device.save()
+
+        assignment = ZabbixTagAssignment.objects.create(zabbixtag=self.tag, assigned_object_type=self.device_ct, assigned_object_id=self.device.id)
+        context = assignment.get_context()
+
+        self.assertEqual(context['site'], self.device.site)
+        self.assertEqual(context['device_type'], self.device_type)
+        self.assertEqual(context['manufacturer'], self.manufacturer)
+
+    def test_render_can_use_related_device_context(self):
+        self.device.device_type = self.device_type
+        self.device.save()
+        self.tag.value = '{{ site.name }} - {{ device_type.model }} - {{ manufacturer.name }}'
+        self.tag.save()
+
+        assignment = ZabbixTagAssignment.objects.create(zabbixtag=self.tag, assigned_object_type=self.device_ct, assigned_object_id=self.device.id)
+        rendered, success = assignment.render()
+
+        self.assertTrue(success)
+        self.assertEqual(rendered, f'{self.device.site.name} - {self.device_type.model} - {self.manufacturer.name}')
 
     def test_str_method_with_name(self):
         assignment = ZabbixTagAssignment.objects.create(zabbixtag=self.tag, assigned_object_type=self.device_ct, assigned_object_id=self.device.id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nbxsync"
-version = "1.0.3"
+version = "1.0.4"
 authors = [
   { name="Opensource ICT Solutions", email="info@oicts.com" },
 ]


### PR DESCRIPTION
# Add related object context to Zabbix tag and hostgroup templates

## Summary

Add related NetBox object context to templated Zabbix tags and hostgroups.

Previously, templates only had access to the assigned object through `object`, plus the tag or hostgroup fields. This change exposes common related objects directly in the Jinja2 context when available.

## What Changed

This PR adds the following template variables for Zabbix tag and hostgroup templates:

- `device`
- `site`
- `tenant`
- `role`
- `device_type`
- `manufacturer`

This allows templates such as:

`{{ site.name }}`
`{{ device.name }}`
`{{ device_type.model }}`
`{{ manufacturer.name }}`

## Why

This makes Zabbix tag and hostgroup templates easier to write and more flexible.

For example, users can now build dynamic tag or hostgroup values from related NetBox data without having to access everything indirectly through `object`.

## Implementation

- Updated `ZabbixTagAssignment.get_context()` to include related object context.
- Updated `ZabbixHostgroupAssignment.get_context()` to include related object context.
- Added tests for the new context variables.
- Added render tests confirming templates can use related fields.

## Testing

- `git diff --check` passed.
- `ruff` was not run because it is not installed in this container.
- Django tests were not run from this checkout because there is no local `manage.py` in `/opt/nbxsync`.