### PR TITLE
ci: run CI on development branch pushes and PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - "develop"
+      - "development"
       - "main"
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
@@ -11,7 +11,7 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+rc[0-9]+"
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: ["main"]
+    branches: ["main", "development"]
 
 concurrency:
   group: ci-${{ github.event_name }}-${{ github.ref }}-${{ github.actor }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - "develop"
+      - "development"
       - "main"
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
@@ -11,7 +12,7 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+rc[0-9]+"
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: ["main"]
+    branches: ["main", "development"]
 
 concurrency:
   group: ci-${{ github.event_name }}-${{ github.ref }}-${{ github.actor }}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,31 +2,31 @@
 
 We use a simple GitFlow-lite:
 
-- **Working branch:** `develop`
+- **Working branch:** `development`
 - **Release branch:** `main`
-- **Feature branches:** branch off `develop`, merge back into `develop`
-- **Releases:** done via a PR from `develop` → `main`, then a version tag on `main`
+- **Feature branches:** branch off `development`, merge back into `development`
+- **Releases:** done via a PR from `development` → `main`, then a version tag on `main`
 
 ## Daily development
 
-1. Branch from `develop` into a new branch:
+1. Branch from `development` into a new branch:
 
     ```bash
-    git checkout develop
-    git pull origin develop
+    git checkout development
+    git pull origin development
     git switch -c feature/my-change
     ```
 
 2. Do the work (tests, docs, migrations as needed).
-3. Open a PR from your feature branch into develop.
+3. Open a PR from your feature branch into development.
 4. CI must pass (lint, tests, coverage ≥ 85%, migrations check).
-5. Merge the PR into develop (squash or rebase merges preferred).
+5. Merge the PR into development (squash or rebase merges preferred).
 
-   >  Keep your feature branch rebased on develop to avoid drift.
+   >  Keep your feature branch rebased on development to avoid drift.
 
 ## Preparing a release
 
-1. Open a release PR from develop → main.
+1. Open a release PR from development → main.
 2. Ensure CI passes on that PR.
 3. Merge the PR into main (squash merge recommended).
 4. Tag the merge commit on main with the new version (see RELEASE.md).
@@ -39,9 +39,9 @@ For urgent production fixes:
 
 1. Branch from main, implement fix, open PR → main.
 2. After merge, tag and release (see RELEASE.md).
-3. Back-merge or cherry-pick the fix into develop to keep branches in sync.
+3. Back-merge or cherry-pick the fix into development to keep branches in sync.
 
 ## Conventions
 
 - Keep PR titles meaningful (Conventional Commits encouraged) for clean release notes.
-- No direct pushes to develop or main (branch protections enforced).
+- No direct pushes to development or main (branch protections enforced).


### PR DESCRIPTION
## Summary

CI never runs on this repo's working branch. 1.0.5 still triggers on `develop` and `pull_request` only for `main`, so PRs into `development` get no check run.

**Rebased onto 1.0.5 `development` (`36fb2c4`).**

- `ci.yml`: push trigger `development` (was `develop`); add `development` to `pull_request` branches
- Keep 1.0.5's NetBox **v4.6.7** pin (this PR does not retarget CI at `main`)
- `DEVELOPMENT.md`: replace stale `develop` references

Two files, no functional plugin change. Merge first so every subsequent PR gets a real signal.

**Scope frozen** at tip `b6f77d8`.
