### PR TITLE
feat: resolve IP from iDRAC/management interface with primary_ip fallback

### DIFF
--- a/nbxsync/utils/sync/hostinterfacesync.py
+++ b/nbxsync/utils/sync/hostinterfacesync.py
@@ -31,7 +31,23 @@ class HostInterfaceSync(ZabbixSyncBase):
         ipaddr = ''
         if self.obj.ip_id:
             ipaddr = IPAddress.objects.get(id=self.obj.ip_id).address.ip
-
+        elif self.context.get('_instance'):
+            instance = self.context.get('_instance')
+            # Check for a management (OOB) interface — e.g. iDRAC, iLO, BMC.
+            # If the device has an interface flagged mgmt_only with a name
+            # starting with "iDRAC", use its IP for this interface.
+            mgmt_iface = getattr(instance, 'interfaces', None)
+            if mgmt_iface is not None:
+                idrac = mgmt_iface.filter(mgmt_only=True, name__istartswith='iDRAC').first()
+                if idrac:
+                    idrac_ip = idrac.ip_addresses.first()
+                    if idrac_ip:
+                        ipaddr = idrac_ip.address.ip
+            # Fall back to the device's primary IP
+            if not ipaddr:
+                primary_ip = getattr(instance, 'primary_ip4', None) or getattr(instance, 'primary_ip6', None)
+                if primary_ip:
+                    ipaddr = primary_ip.address.ip
         dns_name, _ = self.obj.render_dns()
         result = {
             'hostid': hostid,

--- a/nbxsync/utils/sync/hostinterfacesync.py
+++ b/nbxsync/utils/sync/hostinterfacesync.py
@@ -33,16 +33,17 @@ class HostInterfaceSync(ZabbixSyncBase):
             ipaddr = IPAddress.objects.get(id=self.obj.ip_id).address.ip
         elif self.context.get('_instance'):
             instance = self.context.get('_instance')
-            # Check for a management (OOB) interface — e.g. iDRAC, iLO, BMC.
-            # If the device has an interface flagged mgmt_only with a name
-            # starting with "iDRAC", use its IP for this interface.
-            mgmt_iface = getattr(instance, 'interfaces', None)
-            if mgmt_iface is not None:
-                idrac = mgmt_iface.filter(mgmt_only=True, name__istartswith='iDRAC').first()
-                if idrac:
-                    idrac_ip = idrac.ip_addresses.first()
-                    if idrac_ip:
-                        ipaddr = idrac_ip.address.ip
+            # Check for a management (OOB) interface (e.g. iDRAC, iLO, BMC).
+            # Only applies to SNMP interfaces (type=2); agent interfaces
+            # always use the primary IP.
+            if self.obj.type == 2:
+                mgmt_iface = getattr(instance, 'interfaces', None)
+                if mgmt_iface is not None:
+                    idrac = mgmt_iface.filter(mgmt_only=True, name__istartswith='iDRAC').first()
+                    if idrac:
+                        idrac_ip = idrac.ip_addresses.first()
+                        if idrac_ip:
+                            ipaddr = idrac_ip.address.ip
             # Fall back to the device's primary IP
             if not ipaddr:
                 primary_ip = getattr(instance, 'primary_ip4', None) or getattr(instance, 'primary_ip6', None)


### PR DESCRIPTION
## Summary

Add a three-tier IP resolution fallback chain for `ZabbixHostInterface` when no static IP is set on the interface object:

1. **`self.obj.ip_id`** — static IPAddress FK (existing behavior, unchanged)
2. **iDRAC/management interface** — if the device being synced has a NetBox interface with `mgmt_only=True` and name starting with `iDRAC`, use its assigned IP address
3. **`primary_ip4`/`primary_ip6`** — fall back to the device's primary IP (ported from the integration-test branch)

## Motivation

Dell servers running VMware ESXi have two independent network interfaces:
- **ESXi management** (vmk0) — monitored via Zabbix agent (primary_ip4)
- **iDRAC** (OOB management) — monitored via SNMP (separate IP, e.g. 10.0.103.x)

In NetBox, the iDRAC interface is already present as a `mgmt_only=True` interface named `iDRAC 10 (NIC.1)` with the OOB IP assigned. This patch lets nbxsync automatically detect and use that IP for a second SNMP interface on the same Zabbix host.

## Usage

1. Import the `Dell iDRAC by SNMP` Zabbix template
2. Create a `ZabbixHostInterface` (SNMP, port 161) assigned to **Manufacturer `Dell``
3. During sync, the IP resolves automatically:
   - Dell servers **with** iDRAC interface → SNMP interface uses iDRAC OOB IP
   - Dell servers **without** iDRAC → falls back to primary_ip4
   - Non-Dell devices → not affected (interface not inherited)

## No model changes

No new fields, no migration, no `use_oob_ip` flag. Pure logic in `get_create_params()`. The detection uses existing NetBox data: `mgmt_only=True` + `name__istartswith='iDRAC'`.

## Files changed

- `nbxsync/utils/sync/hostinterfacesync.py` — 17 insertions, 1 deletion in `get_create_params()`