### PR TITLE
fix(inheritance): VMs linked to a hosting device inherit host-level assignments (manufacturer/role templates leak to guests)

### DIFF
--- a/nbxsync/tests/utils/test_get_assigned_zabbixobjects.py
+++ b/nbxsync/tests/utils/test_get_assigned_zabbixobjects.py
@@ -49,3 +49,36 @@ class GetAssignedZabbixObjectsTestCase(TestCase):
         self.assertEqual(len(result['macros']), 1)
         self.assertEqual(len(result['tags']), 1)
         self.assertEqual(len(result['hostgroups']), 1)
+
+
+class VirtualMachineDeviceLeakTestCase(TestCase):
+    """A VM linked to its hosting device (NetBox 4.3+) must not inherit the
+    host's hardware-tier assignments (manufacturer etc. via 'device'-prefixed
+    chain paths). A guest is not the hypervisor's hardware.
+    """
+
+    def setUp(self):
+        from virtualization.models import VirtualMachine
+
+        self.server = ZabbixServer.objects.create(name='Leak Server', url='http://zabbix.local', token='abc123', validate_certs=True)
+        self.template = ZabbixTemplate.objects.create(name='Vendor OOB by SNMP', zabbixserver=self.server, templateid=10255)
+        self.dell = Manufacturer.objects.create(name='Dell', slug='dell-oss')
+        self.host = create_test_device(name='esx-host-01')
+        host_type = self.host.device_type
+        host_type.manufacturer = self.dell
+        host_type.save()
+        self.vm = VirtualMachine.objects.create(name='guest-vm-01', device=self.host)
+
+        self.assignment = ZabbixTemplateAssignment.objects.create(
+            zabbixtemplate=self.template,
+            assigned_object_type=ContentType.objects.get_for_model(Manufacturer),
+            assigned_object_id=self.dell.pk,
+        )
+
+    def test_device_inherits_manufacturer_template(self):
+        result = get_assigned_zabbixobjects(self.host)
+        self.assertIn(self.template.pk, [obj.zabbixtemplate_id for obj in result['templates']])
+
+    def test_vm_does_not_inherit_manufacturer_template_via_associated_device(self):
+        result = get_assigned_zabbixobjects(self.vm)
+        self.assertNotIn(self.template.pk, [obj.zabbixtemplate_id for obj in result['templates']])

--- a/nbxsync/utils/inheritance.py
+++ b/nbxsync/utils/inheritance.py
@@ -1,11 +1,12 @@
 from collections import OrderedDict
 
-from django.db.models import Model, QuerySet
-from django.db.models.manager import BaseManager
 from django.contrib.contenttypes.models import ContentType
+from django.db.models import QuerySet
+from django.db.models.manager import BaseManager
+from virtualization.models import VirtualMachine
 
 from nbxsync.constants import PATH_LABELS
-from nbxsync.models import ZabbixHostgroupAssignment, ZabbixHostInterface, ZabbixHostInventory, ZabbixMacroAssignment, ZabbixTagAssignment, ZabbixTemplateAssignment, ZabbixConfigurationGroupAssignment
+from nbxsync.models import ZabbixConfigurationGroupAssignment, ZabbixHostgroupAssignment, ZabbixHostInterface, ZabbixHostInventory, ZabbixMacroAssignment, ZabbixTagAssignment, ZabbixTemplateAssignment
 from nbxsync.settings import get_plugin_settings
 from nbxsync.tables import ZabbixHostgroupAssignmentObjectViewTable, ZabbixMacroAssignmentObjectViewTable, ZabbixTagAssignmentObjectViewTable, ZabbixTemplateAssignmentObjectViewTable
 
@@ -116,6 +117,15 @@ def resolve_inherited_zabbix_assignments(assigned_object, zabbixserver=None):
 
     pluginsettings = get_plugin_settings()
     for path in pluginsettings.inheritance_chain:
+        # 'device'-prefixed paths describe the *associated physical device*
+        # (the VDC's parent, or — since NetBox 4.3 — a VM's hosting device).
+        # For a VirtualMachine that association is the hypervisor/sidecar, so
+        # walking these paths would leak host properties (manufacturer, role,
+        # hardware templates) onto the guest. VDCs keep the paths: a VDC is
+        # part of its parent device by definition.
+        if path and path[0] == 'device' and isinstance(assigned_object, VirtualMachine):
+            continue
+
         related_obj = resolve_path(assigned_object, path)
         # label = '.'.join(path)
 


### PR DESCRIPTION
## Problem

Since NetBox 4.3, `VirtualMachine.device` links a guest VM to its hosting device. nbxsync's inheritance resolver walks every path in the (default) `inheritance_chain` generically — including `('device',)`, `('device','role')`, `('device','platform')`, `('device','device_type')`, `('device','device_type','manufacturer')` — which describe properties of the *associated physical device*.

Result: **any assignment made for physical hardware also lands on that hardware's guest VMs.** Reproduced live: a template assigned at Manufacturer *Dell* level (e.g. an OOB/iDRAC template) was attached to every VM hosted on Dell servers; the VMs even picked up the host's DeviceRole via `('device','role')`.

A guest VM's monitoring profile must come from its own metadata (role, platform, site, cluster) — never from the hypervisor's hardware tier.

This bug exists in `development` today (the walker and the default chain are upstream code); it surfaces on any install where VMs are linked to devices (NetBox ≥ 4.3) and any Device-scoped hierarchy assignments exist.

## Fix

Skip `device`-prefixed chain paths when the assigned object is a `VirtualMachine`. Devices and VDCs keep them — a VDC is part of its parent device by definition. 2-line guard + comment, no other behavior touched.

## Tests

- `test_vm_does_not_inherit_manufacturer_template_via_associated_device` — regression: linked VM does not receive the manufacturer template
- `test_device_inherits_manufacturer_template` — the physical host still does (unchanged positive path)

Verified end-to-end on NetBox 4.5.10 / Zabbix 7.0: before the fix a VM running on a Dell PowerEdge host received the Dell manufacturer template; after the fix it receives only its own role/platform-driven assignments.

(The same fix is also included in the stacked #125 so the feature branches stay consistent; this PR is the standalone upstream fix.)