### PR TITLE
Fix DeleteHostGroupAssignmentClonesJob deleting all hostgroups

### DIFF
--- a/nbxsync/jobs/cfggroup.py
+++ b/nbxsync/jobs/cfggroup.py
@@ -302,13 +302,14 @@ class PropagateHostGroupAssignmentJob:
 class DeleteHostGroupAssignmentClonesJob:
     def __init__(self, **kwargs):
         self.configgroup_pk = kwargs['configgroup_pk']
+        self.zabbixhostgroup_pk = kwargs['zabbixhostgroup_pk']
 
     def run(self):
         assignments = ZabbixHostgroupAssignment.objects.filter(zabbixconfigurationgroup_id=self.configgroup_pk).select_related('assigned_object_type')
 
         def _delete():
             for assigned in assignments:
-                ZabbixHostgroupAssignment.objects.filter(assigned_object_type=assigned.assigned_object_type, assigned_object_id=assigned.assigned_object_id, zabbixconfigurationgroup_id=self.configgroup_pk).delete()
+                ZabbixHostgroupAssignment.objects.filter(zabbixhostgroup_id=self.zabbixhostgroup_pk, assigned_object_type=assigned.assigned_object_type, assigned_object_id=assigned.assigned_object_id, zabbixconfigurationgroup_id=self.configgroup_pk).delete()
 
         transaction.on_commit(_delete)
 

--- a/nbxsync/signals/zabbixhostgroupassignment.py
+++ b/nbxsync/signals/zabbixhostgroupassignment.py
@@ -33,4 +33,4 @@ def handle_postdelete_zabbixhostgroupassignment(sender, instance, **kwargs):
     if not is_configgroup_assignment(instance):
         return
 
-    delete_hostgroup_assignment_clones.delay(configgroup_pk=instance.assigned_object_id)
+    delete_hostgroup_assignment_clones.delay(configgroup_pk=instance.assigned_object_id, zabbixhostgroup_pk=instance.zabbixhostgroup_id)

--- a/nbxsync/worker.py
+++ b/nbxsync/worker.py
@@ -95,8 +95,8 @@ def propagate_hostgroup_assignment(assignment_pk):
 
 
 @job('low')
-def delete_hostgroup_assignment_clones(configgroup_pk):
-    DeleteHostGroupAssignmentClonesJob(configgroup_pk=configgroup_pk).run()
+def delete_hostgroup_assignment_clones(configgroup_pk, zabbixhostgroup_pk):
+    DeleteHostGroupAssignmentClonesJob(configgroup_pk=configgroup_pk, zabbixhostgroup_pk=zabbixhostgroup_pk).run()
 
 
 @job('low')


### PR DESCRIPTION
When a ZabbixHostgroupAssignment assigned to a ConfigurationGroup was deleted, the cleanup job deleted ALL hostgroup assignment clones for every member of that config group instead of only the clones of the one hostgroup that was removed. Matches the bug pattern already correctly handled by DeleteTagAssignmentClonesJob and DeleteTemplateAssignmentClonesJob.

Two missing pieces:
- signal: .delay() omitted zabbixhostgroup_pk, so the job never knew which specific hostgroup was deleted
- job: _delete() filter omitted zabbixhostgroup_id=self.zabbixhostgroup_pk, so it matched and wiped all (object, configgroup) hostgroup rows